### PR TITLE
Add container support using Docker

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,37 @@
+worker_processes 5;
+events { worker_connections 1024; }
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    charset utf-8;
+    server_tokens off;
+    tcp_nopush on;
+    tcp_nodelay off;
+
+    server {
+        listen 80;
+
+        root /var/www/html;
+        index index.html index.htm index.php;
+
+        access_log /dev/stdout;
+        error_log /dev/stderr;
+
+        location / {
+            try_files $uri $uri/ /index.html /index.php?$query_string;
+        }
+
+        location = /favicon.ico { log_not_found off; access_log off; }
+        location = /robots.txt { log_not_found off; access_log off; }
+
+        error_page 404 /index.php;
+
+        location ~ \.php$ {
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass php:9000;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            include fastcgi_params;
+        }
+    }
+}

--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:5-fpm
+
+# Install modules
+RUN apt-get update && apt-get install -y \
+        git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  php:
+    build: .docker/php
+    volumes:
+      - .:/var/www/html
+      - .:/repos/gitlist
+
+  nginx:
+    image: nginx
+    volumes:
+      - .:/var/www/html
+      - ./.docker/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "8080:80"
+    links:
+      - php


### PR DESCRIPTION
This pull request adds container support using docker. 
It uses Nginx and PHP5-fpm. 

The web interface is exposed over port 8080 (http://localhost:8080) and the gitlist sources are mounted as the application folder and under `/repos/gitlist`. Using `/repos` in your config.ini should display the sources with gitlist.