### PR TITLE
Fixes issue #37 and adds a pagination button.

### DIFF
--- a/src/Controller/BlobController.php
+++ b/src/Controller/BlobController.php
@@ -76,7 +76,7 @@ class BlobController implements ControllerProviderInterface
             list($branch, $file) = $app['util.routing']
                 ->parseCommitishPathParam($commitishPath, $repo);
 
-            $filePatchesLog = $repository->getCommitsLogPatch($file);
+            $filePatchesLog = $repository->getCommitsLogPatch($file,$branch);
             $breadcrumbs = $app['util.view']->getBreadcrumbs($file);
 
             return $app['twig']->render('logpatch.twig', array(

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -38,6 +38,8 @@ class Repository extends BaseRepository
      * Show Patches that where apllied to the selected file
      *
      * @param  string $file File path for which we will retrieve a list of patch logs
+     * @param  string $revisions Revision range used for the pagination of commits
+     * @param  int $max_count Maximum number of commits to process for one page
      * @return array  Collection of Commits data
      */
     public function getCommitsLogPatch($file, $revisions = "", $max_count = 100)

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -40,7 +40,7 @@ class Repository extends BaseRepository
      * @param  string $file File path for which we will retrieve a list of patch logs
      * @return array  Collection of Commits data
      */
-    public function getCommitsLogPatch($file)
+    public function getCommitsLogPatch($file, $revisions = "", $max_count = 100)
     {
         $record_delimiter = chr(hexdec("0x1e"));
         $file_patches = $this->getClient()->run($this,
@@ -51,23 +51,31 @@ class Repository extends BaseRepository
             . "<commiter_date>%ct</commiter_date>"
             . "<message><![CDATA[%s]]></message>"
             . "<body><![CDATA[%b]]></body>"
-            . "</item>\" -- \"$file\""
+            . "</item>\" --max-count=".($max_count+1)." $revisions -- \"$file\""
         );
 
         $patch_collection = array();
-        foreach ( preg_split('/('.$record_delimiter.'\<item\>)/', $file_patches,null, PREG_SPLIT_NO_EMPTY) as $patches) {
-            $patches = '<item>' . $patches;
-            $xmlEnd = strpos($patches, '</item>') + 7;
-            $commitInfo = substr($patches, 0, $xmlEnd);
-            $commitData = substr($patches, $xmlEnd);
+        $format = new PrettyFormat;
+        $commits = preg_split('/'.$record_delimiter.'(?:<item>)/', $file_patches, null, PREG_SPLIT_NO_EMPTY);
+        $file_patches = null;
+        $pagination = (count ($commits) == $max_count+1);
+        $count = 0;
+        foreach ($commits as $patch) {
+            $xmlEnd = strpos($patch, '</item>') + strlen ('</item>');
+            $commitInfo = "<item>".substr($patch, 0, $xmlEnd);
+            $commitData = substr($patch, $xmlEnd);
             $logs = explode("\n", $commitData);
 
             // Read commit metadata
-            $format = new PrettyFormat;
             $data = $format->parse($commitInfo);
             $commit = new Commit;
             $commit->importData($data[0]);
             $commit->setDiffs($this->readDiffLogs($logs));
+
+            // Limit number of commits due to memory constrains
+            $count++;
+            if ($pagination && ($count == $max_count+1)) { $commit->setShortHash(null); }
+
             $patch_collection[] = $commit;
         }
 

--- a/themes/bootstrap3/twig/logpatch.twig
+++ b/themes/bootstrap3/twig/logpatch.twig
@@ -7,37 +7,52 @@
 {% block content %}
 
     {% include 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}
-    
-    {% for commit in commits %}
-        
-        <div class="commit-view">
-            <div class="commit-header">
-            <span class="pull-right">
-                <a class="btn btn-default btn-sm" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><span class="fa fa-list-alt"></span> Browse code</a></span>
-                <h4>{{ commit.message }}</h4>
-            </div>
-            <div class="commit-body">
-                {% if commit.body is not empty %}
-                    <p>{{ commit.body | nl2br }}</p>
-                {% endif %}
-                <img src="{{ avatar(commit.author.email, 32) }}" class="pull-left space-right" />
-                <span>
-                <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
-                    {% if commit.author.email != commit.commiter.email %}
-                        &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
-                    {% endif %}
-                    <br />Showing {{ commit.changedFiles }} changed files
-            </span>
-            </div>
-        </div>
 
-        {% for diff in commit.diffs %}
+    {% for commit in commits %}
+
+        {% if commit.shortHash is null %}
+
+            <div class="commit-view">
+                <div class="commit-header">
+                    <span class="pull-right">
+                        <a class="btn btn-default btn-sm" href="{{ path('logpatch', {repo: repo, commitishPath: commit.hash ~ '/' ~ commit.diffs[0].file}) }}" title="Next page of Patch Log"><span class="fa fa-calendar"></span> Next page</a>
+                    </span>
+                    <h4>Output limited due to page length...</h4>
+                </div>
+            </div>
+
+        {% else %}
+
+            <div class="commit-view">
+                <div class="commit-header">
+                    <span class="pull-right">
+                        <a class="btn btn-default btn-sm" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><span class="fa fa-list-alt"></span> Browse code</a>
+                    </span>
+                    <h4>{{ commit.message }}</h4>
+                </div>
+                <div class="commit-body">
+                    {% if commit.body is not empty %}
+                        <p>{{ commit.body | nl2br }}</p>
+                    {% endif %}
+                    <img src="{{ avatar(commit.author.email, 32) }}" class="pull-left space-right" />
+                    <span>
+                        <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
+                        {% if commit.author.email != commit.commiter.email %}
+                            &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
+                        {% endif %}
+                        <br />Showing {{ commit.changedFiles }} changed files
+                    </span>
+                </div>
+            </div>
+
+            {% for diff in commit.diffs %}
             <div class="source-view">
                 <div class="source-header">
                     <div class="meta"><a id="diff-{{ loop.index }}">{{ diff.file }}</div>
 
                     <div class="btn-group pull-right">
                         <a href="{{ path('commits', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}"  class="btn btn-default btn-sm"><span class="fa fa-list-alt"></span> History</a>
+                        <a href="{{ path('blame', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}"  class="btn btn-default btn-sm"><span class="fa fa-bullhorn"></span> Blame</a>
                         <a href="{{ path('blob', {repo: repo, commitishPath: commit.hash ~'/' ~ diff.file}) }}"  class="btn btn-default btn-sm"><span class="fa fa-file"></span> View file @ {{ commit.shortHash }}</a>
                     </div>
                 </div>
@@ -74,11 +89,13 @@
                     </table>
                 </div>
             </div>
-        {% endfor %}
+            {% endfor %}
+
+        {% endif %}
 
     {% endfor %}
 
-    
+
 
     <hr />
 {% endblock %}

--- a/themes/default/twig/logpatch.twig
+++ b/themes/default/twig/logpatch.twig
@@ -1,42 +1,58 @@
 {% extends 'layout_page.twig' %}
 
-{% set page = 'commits' %}
+{% set page = 'Log Patches' %}
 
 {% block title %}GitList{% endblock %}
 
 {% block content %}
-    
+
     {% include 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}
-    
+
     {% for commit in commits %}
 
-        <div class="commit-view">
-            <div class="commit-header">
-                <span class="pull-right"><a class="btn btn-small" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><i class="icon-list-alt"></i> Browse code</a></span>
-                <h4>{{ commit.message }}</h4>
-            </div>
-            <div class="commit-body">
-                {% if commit.body is not empty %}
-                    <p>{{ commit.body | nl2br }}</p>
-                {% endif %}
-                <img src="{{ avatar(commit.author.email, 32) }}" class="pull-left space-right" />
-                <span>
-                <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
-                    {% if commit.author.email != commit.commiter.email %}
-                        &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
-                    {% endif %}
-                    <br />Showing {{ commit.changedFiles }} changed files
-            </span>
-            </div>
-        </div>
+        {% if commit.shortHash is null %}
 
-        {% for diff in commit.diffs %}
+            <div class="commit-view">
+                <div class="commit-header">
+                    <span class="pull-right">
+                        <a class="btn btn-small" href="{{ path('logpatch', {repo: repo, commitishPath: commit.hash ~ '/' ~ commit.diffs[0].file}) }}" title="Next page of Patch Log"><i class="icon-calendar"></i> Next page</a>
+                    </span>
+                    <h4>Output limited due to page length...</h4>
+                </div>
+            </div>
+
+        {% else %}
+
+            <div class="commit-view">
+                <div class="commit-header">
+                    <span class="pull-right">
+                        <a class="btn btn-small" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><i class="icon-list-alt"></i> Browse code</a>
+                    </span>
+                    <h4>{{ commit.message }}</h4>
+                </div>
+                <div class="commit-body">
+                    {% if commit.body is not empty %}
+                        <p>{{ commit.body | nl2br }}</p>
+                    {% endif %}
+                    <img src="{{ avatar(commit.author.email, 32) }}" class="pull-left space-right" />
+                    <span>
+                        <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
+                        {% if commit.author.email != commit.commiter.email %}
+                            &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
+                        {% endif %}
+                        <br />Showing {{ commit.changedFiles }} changed files
+                    </span>
+                </div>
+            </div>
+
+            {% for diff in commit.diffs %}
             <div class="source-view">
                 <div class="source-header">
                     <div class="meta"><a id="diff-{{ loop.index }}">{{ diff.file }}</div>
 
                     <div class="btn-group pull-right">
                         <a href="{{ path('commits', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}" class="btn btn-small"><i class="icon-list-alt"></i> History</a>
+                        <a href="{{ path('blame', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}" class="btn btn-small"><i class="icon-bullhorn"></i> Blame</a>
                         <a href="{{ path('blob', {repo: repo, commitishPath: commit.hash ~'/' ~ diff.file}) }}" class="btn btn-small"><i class="icon-file"></i> View file @ {{ commit.shortHash }}</a>
                     </div>
                 </div>
@@ -73,8 +89,10 @@
                     </table>
                 </div>
             </div>
-        {% endfor %}
-        
+            {% endfor %}
+
+        {% endif %}
+
     {% endfor %}
 
 


### PR DESCRIPTION
Added a pagination for the "Patch Log" with a default of 100 entries per page.
The reason is that for long Patch Logs, there might occur very quickly a memory exhaustion from PHP, which returns just a blank page.

Also one should note that no unneccessary "new Something()" is present in a loop!